### PR TITLE
Add pointers to Spring Cloud Task guide in the Microsite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+*~
+.#*
+*#
+*.sw*
+_site/
+.factorypath
+.gradletasknamecache
+.DS_Store
+.checkstyle
+/application.yml
+/application.properties
+asciidoctor.css
+atlassian-ide-plugin.xml
+bin/
+build/
+dump.rdb
+out
+spring-shell.log
+target/
+test-output
+logs/
+scdf-logs/
+.attach_pid*
+
+# Eclipse artifacts, including WTP generated manifests
+.classpath
+.project
+.settings/
+.springBeans
+spring-*/src/main/java/META-INF/MANIFEST.MF
+
+# IDEA artifacts and output dirs
+*.iml
+*.ipr
+*.iws
+.idea/
+rebel.xml
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ rebel.xml
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@ This guide walks you through an overview of Spring Cloud Task and the process of
 batch application.
 
 === What is Spring Cloud Task?
-A framework for building short-lived Spring Boot microservices for batch data processing. You can learn more about
+A framework for building short-lived Spring Boot microservices, such as batch data processing jobs. You can learn more about
 the framework from the link:https://spring.io/projects/spring-cloud-task[project-site],
 link:https://spring.io/projects/spring-cloud-task#learn[documentation],
 and link:https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples].
@@ -21,5 +21,5 @@ machine.
 link:https://dataflow.spring.io/docs/batch-developer-guides/batch/spring-batch/[Spring Batch Job as a Task]
 
 == Summary
-Congratulations! You have learned Spring Cloud Task's high-level overview, and you were able to build, test and launch
+Congratulations! You have completed Spring Cloud Task's high-level overview, and you were able to build, test and launch
 a simple task and as well a batch-job.

--- a/README.adoc
+++ b/README.adoc
@@ -1,1 +1,25 @@
+== Getting Started with Spring Cloud Task
+This guide walks you through an overview of Spring Cloud Task and the process of creating and launching short-lived
+batch application.
 
+=== What is Spring Cloud Task?
+A framework for building short-lived Spring Boot microservices for batch data processing. You can learn more about
+the framework from the link:https://spring.io/projects/spring-cloud-task[project-site],
+link:https://spring.io/projects/spring-cloud-task#learn[documentation],
+and link:https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples].
+
+=== Simple Task Application
+In the following guide, we develop a Spring Boot application that uses Spring Cloud Task and deploy it to Cloud Foundry,
+Kubernetes, and your local machine.
+
+link:https://dataflow.spring.io/docs/batch-developer-guides/batch/spring-task/[Simple Task Application]
+
+=== Spring Batch Job as a Task
+In the following guide, we develop a Spring Batch application and deploy it to Cloud Foundry, Kubernetes, and your local
+machine.
+
+link:https://dataflow.spring.io/docs/batch-developer-guides/batch/spring-batch/[Spring Batch Job as a Task]
+
+== Summary
+Congratulations! You have learned Spring Cloud Task's high-level overview, and you were able to build, test and launch
+a simple task and as well a batch-job.


### PR DESCRIPTION
The goal with this approach is to avoid duplicating content that we already maintain in the Microsite. And, of course, steer everyone towards the Microsite since that is the central source of truth for all the things SCDF and ecosystem.